### PR TITLE
PDF outline enrichment (real heading levels via PyMuPDF)

### DIFF
--- a/extractor/backends/docling_backend.py
+++ b/extractor/backends/docling_backend.py
@@ -12,7 +12,7 @@ Later steps can switch to Docling's structured JSON if needed.
 from docling.document_converter import DocumentConverter
 
 
-def extract_markdown(path: str) -> str:
+def docling_md(path: str) -> str:
     """
     Convert a file path (PDF) to Markdown using Docling.
     Returns: single Markdown string.
@@ -22,3 +22,8 @@ def extract_markdown(path: str) -> str:
     md_text = doc.export_to_markdown()
     # Note: We keep raw Markdown; parsing happens downstream.
     return md_text
+
+
+def extract_markdown(path: str) -> str:
+    """Backward-compatible alias for docling_md."""
+    return docling_md(path)

--- a/extractor/backends/pymupdf4llm_backend.py
+++ b/extractor/backends/pymupdf4llm_backend.py
@@ -1,0 +1,16 @@
+import fitz
+import pymupdf4llm
+
+
+def extract_markdown_pages(path: str):
+    """
+    Yield tuples: (page_no, markdown_string) for each page (1-based).
+    """
+    doc = fitz.open(path)
+    try:
+        for i in range(doc.page_count):
+            # to_markdown on a single page
+            md = pymupdf4llm.to_markdown(path, page_numbers=[i])
+            yield (i + 1, md)
+    finally:
+        doc.close()

--- a/extractor/cli.py
+++ b/extractor/cli.py
@@ -18,11 +18,13 @@ import argparse
 import logging
 import os
 from datetime import datetime
+
 from tqdm import tqdm
 
-from backends.docling_backend import extract_markdown
-from sentence_postprocess import parse_markdown_to_rows
+from backends.docling_backend import docling_md
 from export import to_xlsx
+from sentence_postprocess import parse_markdown_to_rows
+from utils.outline import get_outline_ranges, label_for_page
 
 LOGGER = logging.getLogger("green_guard.extractor")
 
@@ -47,6 +49,18 @@ def main():
         default="INFO",
         help="DEBUG, INFO, WARNING, ERROR, CRITICAL (default=INFO)",
     )
+    parser.add_argument(
+        "--backend",
+        dest="backend",
+        choices=["docling", "pymupdf4llm"],
+        default="docling",
+        help="Extraction backend (default=docling)",
+    )
+    parser.add_argument(
+        "--use-pdf-outline",
+        action="store_true",
+        help="If set (and page_no is available), override h1/h2/h3 from PDF bookmarks.",
+    )
     args = parser.parse_args()
 
     setup_logging(args.log_level)
@@ -61,20 +75,57 @@ def main():
 
     os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
     LOGGER.info("Extraction started")
-    LOGGER.info("Step 1/3: Converting PDF to Markdown via Docling")
+    LOGGER.info("Step 1/3: Converting PDF using backend=%s", args.backend)
 
-    md_text = extract_markdown(input_path)
-    LOGGER.info("Docling conversion complete. Markdown length: %d chars", len(md_text))
-
-    LOGGER.info("Step 2/3: Parsing Markdown into structured rows")
-    rows_iter = parse_markdown_to_rows(md_text, source_file=os.path.basename(input_path))
-
-    # Materialize to list with progress bar for visibility
     rows = []
-    for r in tqdm(rows_iter, desc="Parsing", unit="row"):
-        rows.append(r)
+    if args.backend == "pymupdf4llm":
+        from backends.pymupdf4llm_backend import extract_markdown_pages
+
+        md_pages = list(extract_markdown_pages(input_path))
+        LOGGER.info("Conversion complete via PyMuPDF4LLM. Pages: %d", len(md_pages))
+
+        LOGGER.info("Step 2/3: Parsing Markdown into structured rows")
+        for page_no, md_text in tqdm(md_pages, desc="Parsing pages", unit="page"):
+            for r in parse_markdown_to_rows(
+                md_text,
+                source_file=os.path.basename(input_path),
+                page_no=page_no,
+            ):
+                rows.append(r)
+    else:
+        md_text = docling_md(input_path)
+        LOGGER.info(
+            "Docling conversion complete. Markdown length: %d chars", len(md_text)
+        )
+
+        LOGGER.info("Step 2/3: Parsing Markdown into structured rows")
+        rows_iter = parse_markdown_to_rows(
+            md_text, source_file=os.path.basename(input_path)
+        )
+
+        # Materialize to list with progress bar for visibility
+        for r in tqdm(rows_iter, desc="Parsing", unit="row"):
+            rows.append(r)
 
     LOGGER.info("Parsed %d rows (lines/sentences)", len(rows))
+
+    if args.use_pdf_outline:
+        LOGGER.info("Enriching rows with PDF outline data")
+        ranges = get_outline_ranges(input_path)
+        if ranges:
+            for r in rows:
+                pg = r.get("page_no", 0)
+                if pg > 0:
+                    oh1, oh2, oh3 = label_for_page(ranges, pg)
+                    if oh1 or oh2 or oh3:
+                        r["h1"] = oh1 or r.get("h1", "")
+                        r["h2"] = oh2 or r.get("h2", "")
+                        r["h3"] = oh3 or r.get("h3", "")
+                        r["section_path"] = " > ".join(
+                            [x for x in [r["h1"], r["h2"], r["h3"]] if x]
+                        )
+        else:
+            LOGGER.info("No outline found; skipping enrichment")
 
     LOGGER.info("Step 3/3: Writing to Excel: %s", out_path)
     to_xlsx(rows, out_path)

--- a/extractor/export.py
+++ b/extractor/export.py
@@ -10,9 +10,14 @@ LOGGER = logging.getLogger("green_guard.extractor.export")
 REQUIRED_COLUMNS = [
     "source_file",
     "line_no",
+    "page_no",
     "section_type",
     "heading_level",
     "is_table",
+    "h1",
+    "h2",
+    "h3",
+    "section_path",
     "text",
 ]
 

--- a/extractor/requirements.txt
+++ b/extractor/requirements.txt
@@ -1,4 +1,6 @@
 docling
+pymupdf
+pymupdf4llm
 pandas
 openpyxl
 tqdm

--- a/extractor/sentence_postprocess.py
+++ b/extractor/sentence_postprocess.py
@@ -37,22 +37,37 @@ def _emit_row(
     section_type: str,
     heading_level: Optional[int],
     is_table: int,
+    h1: Optional[str],
+    h2: Optional[str],
+    h3: Optional[str],
+    page_no: int = 0,
 ) -> Dict:
+    path = " > ".join([x for x in [h1, h2, h3] if x])
     return {
         "source_file": source_file,
         "line_no": line_no,
+        "page_no": page_no,
         "section_type": section_type,  # one of: heading, bullet, table, text
         "heading_level": heading_level or 0,
         "is_table": is_table,
+        "h1": h1 or "",
+        "h2": h2 or "",
+        "h3": h3 or "",
+        "section_path": path,
         "text": text.strip(),
     }
 
 
-def parse_markdown_to_rows(md_text: str, source_file: str) -> Iterator[Dict]:
+def parse_markdown_to_rows(md_text: str, source_file: str, page_no: int = 0) -> Iterator[Dict]:
     """
     Generate row dicts from markdown text.
-    Each row has: source_file, line_no, section_type, heading_level, is_table, text
+    Each row has: source_file, line_no, page_no, section_type, heading_level,
+    is_table, h1/h2/h3, section_path, text.
     """
+    current_h1: Optional[str] = ""
+    current_h2: Optional[str] = ""
+    current_h3: Optional[str] = ""
+
     for i, raw in enumerate(md_text.splitlines(), start=1):
         line = raw.rstrip()
         if not line:
@@ -65,13 +80,35 @@ def parse_markdown_to_rows(md_text: str, source_file: str) -> Iterator[Dict]:
         m = _HEADING_RE.match(line)
         if m:
             level = len(m.group("hashes"))
+            heading_text = m.group("text").strip()
+
+            if level == 1:
+                current_h1 = heading_text
+                current_h2 = ""
+                current_h3 = ""
+            elif level == 2:
+                if not current_h1:
+                    current_h1 = ""
+                current_h2 = heading_text
+                current_h3 = ""
+            else:
+                if not current_h1:
+                    current_h1 = ""
+                if not current_h2:
+                    current_h2 = ""
+                current_h3 = heading_text
+
             yield _emit_row(
                 source_file=source_file,
                 line_no=i,
-                text=m.group("text"),
+                text=heading_text,
                 section_type="heading",
                 heading_level=level,
                 is_table=0,
+                h1=current_h1,
+                h2=current_h2,
+                h3=current_h3,
+                page_no=page_no,
             )
             continue
 
@@ -84,6 +121,10 @@ def parse_markdown_to_rows(md_text: str, source_file: str) -> Iterator[Dict]:
                 section_type="table",
                 heading_level=None,
                 is_table=1,
+                h1=current_h1,
+                h2=current_h2,
+                h3=current_h3,
+                page_no=page_no,
             )
             continue
 
@@ -98,6 +139,10 @@ def parse_markdown_to_rows(md_text: str, source_file: str) -> Iterator[Dict]:
                 section_type="bullet",
                 heading_level=None,
                 is_table=0,
+                h1=current_h1,
+                h2=current_h2,
+                h3=current_h3,
+                page_no=page_no,
             )
             continue
 
@@ -112,4 +157,8 @@ def parse_markdown_to_rows(md_text: str, source_file: str) -> Iterator[Dict]:
                     section_type="text",
                     heading_level=None,
                     is_table=0,
+                    h1=current_h1,
+                    h2=current_h2,
+                    h3=current_h3,
+                    page_no=page_no,
                 )

--- a/extractor/utils/outline.py
+++ b/extractor/utils/outline.py
@@ -1,0 +1,44 @@
+from typing import List, Tuple
+
+import fitz  # PyMuPDF
+
+
+def get_outline_ranges(pdf_path: str) -> List[Tuple[int, str, int, int]]:
+    """
+    Return list of (level, title, start_page, end_page) (1-indexed pages, inclusive).
+    If no outline, returns [].
+    """
+    doc = fitz.open(pdf_path)
+    toc = doc.get_toc()  # rows: [level(int), title(str), page(int, 1-based)]
+    if not toc:
+        doc.close()
+        return []
+
+    # Build (level, title, start, end) by peeking next start
+    ranges: List[Tuple[int, str, int, int]] = []
+    for i, (lvl, title, start) in enumerate(toc):
+        end = (toc[i + 1][2] - 1) if i + 1 < len(toc) else doc.page_count
+        # clamp
+        start = max(1, start)
+        end = max(start, min(end, doc.page_count))
+        ranges.append((lvl, title.strip(), start, end))
+    doc.close()
+    return ranges
+
+
+def label_for_page(ranges: List[Tuple[int, str, int, int]], page_no: int) -> Tuple[str, str, str]:
+    """
+    For a given page_no (1-based), return best (h1,h2,h3) derived from outline levels.
+    """
+    # collect all outline entries covering this page
+    covers = [(lvl, title) for (lvl, title, s, e) in ranges if s <= page_no <= e]
+    # Keep top 3 levels
+    h1 = h2 = h3 = ""
+    for lvl, title in sorted(covers, key=lambda x: x[0]):
+        if lvl == 1 and not h1:
+            h1 = title
+        elif lvl == 2 and not h2:
+            h2 = title
+        elif lvl >= 3 and not h3:
+            h3 = title
+    return h1, h2, h3


### PR DESCRIPTION
## Summary
- add a PyMuPDF4LLM backend that emits per-page markdown and expose a --backend selector
- capture page numbers throughout parsing/export and enrich heading metadata via PDF outlines when requested
- store PDF outline helpers and expand the export schema to include heading hierarchy columns

## Testing
- python -m compileall extractor

------
https://chatgpt.com/codex/tasks/task_b_68e3cf299a0883329bb969b5885dc2bd