### PR TITLE
Set docling backend as default and add heuristic heading option

### DIFF
--- a/extractor/cli.py
+++ b/extractor/cli.py
@@ -1,33 +1,16 @@
 #!/usr/bin/env python3
-"""
-CLI for Green Guard Extraction MVP (Step 1).
-
-Pipeline:
-    PDF -> (Docling) Markdown -> parse to structured rows -> export .xlsx
-
-Features:
-- Clear, pedagogical logging explaining each step
-- Robust error handling
-- Simple, consistent output schema
-
-Usage:
-    python extractor/cli.py --in input.pdf --out outputs/output.xlsx --log-level INFO
-"""
-
 import argparse
 import logging
 import os
 from datetime import datetime
-
 from tqdm import tqdm
 
-from backends.docling_backend import docling_md
+from backends.docling_backend import docling_md  # your existing function
 from export import to_xlsx
 from sentence_postprocess import parse_markdown_to_rows
-from utils.outline import get_outline_ranges, label_for_page
+from utils.outline import get_outline_ranges, label_for_page  # keep optional
 
 LOGGER = logging.getLogger("green_guard.extractor")
-
 
 def setup_logging(level: str) -> None:
     numeric = getattr(logging, level.upper(), logging.INFO)
@@ -38,29 +21,18 @@ def setup_logging(level: str) -> None:
     )
     LOGGER.info("Initialized logging at level=%s", level.upper())
 
-
 def main():
-    parser = argparse.ArgumentParser(description="Green Guard — Extraction MVP")
+    parser = argparse.ArgumentParser(description="Green Guard — Extraction (stable default)")
     parser.add_argument("--in", dest="input_path", required=True, help="Path to PDF")
     parser.add_argument("--out", dest="out_path", required=True, help="Path to .xlsx")
-    parser.add_argument(
-        "--log-level",
-        dest="log_level",
-        default="INFO",
-        help="DEBUG, INFO, WARNING, ERROR, CRITICAL (default=INFO)",
-    )
-    parser.add_argument(
-        "--backend",
-        dest="backend",
-        choices=["docling", "pymupdf4llm"],
-        default="docling",
-        help="Extraction backend (default=docling)",
-    )
-    parser.add_argument(
-        "--use-pdf-outline",
-        action="store_true",
-        help="If set (and page_no is available), override h1/h2/h3 from PDF bookmarks.",
-    )
+    parser.add_argument("--backend", choices=["docling", "pymupdf4llm"], default="docling",
+                        help="Extraction backend (default=docling)")
+    parser.add_argument("--use-pdf-outline", action="store_true",
+                        help="If set (and page_no is available), override h1/h2/h3 from PDF bookmarks.")
+    parser.add_argument("--heuristic-headings", action="store_true",
+                        help="Enable optional numbering/caps heuristics for heading detection.")
+    parser.add_argument("--log-level", dest="log_level", default="INFO",
+                        help="DEBUG, INFO, WARNING, ERROR, CRITICAL")
     args = parser.parse_args()
 
     setup_logging(args.log_level)
@@ -74,36 +46,39 @@ def main():
         raise SystemExit(1)
 
     os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
-    LOGGER.info("Extraction started")
-    LOGGER.info("Step 1/3: Converting PDF using backend=%s", args.backend)
+    LOGGER.info("Extraction started | backend=%s | heuristics=%s", args.backend, args.heuristic_headings)
 
     rows = []
     if args.backend == "pymupdf4llm":
         from backends.pymupdf4llm_backend import extract_markdown_pages
-    
         md_pages = list(extract_markdown_pages(input_path))
-        LOGGER.info("Conversion complete via PyMuPDF4LLM. Pages: %d", len(md_pages))
-    
-        # --- SAFETY NET: warn if any pages extracted as empty ---
+        LOGGER.info("Conversion complete via PyMuPDF. Pages: %d", len(md_pages))
+
+        # Safety net: warn if any pages are empty
         empty_pages = [p for p, md in md_pages if not (md and md.strip())]
         if empty_pages:
-            LOGGER.warning(
-                "No markdown extracted for %d page(s): %s",
-                len(empty_pages),
-                empty_pages[:10],  # show only first few
-            )
+            LOGGER.warning("No markdown extracted for %d page(s): %s", len(empty_pages), empty_pages[:10])
 
-        LOGGER.info("Step 2/3: Parsing Markdown into structured rows")
-        rows_iter = parse_markdown_to_rows(
-            md_text, source_file=os.path.basename(input_path)
-        )
+        LOGGER.info("Step 2/3: Parsing page chunks into rows")
+        for page_no, md_text in tqdm(md_pages, desc="Parsing pages", unit="page"):
+            for r in parse_markdown_to_rows(md_text,
+                                            source_file=os.path.basename(input_path),
+                                            page_no=page_no,
+                                            use_heuristics=args.heuristic_headings):
+                rows.append(r)
+    else:
+        LOGGER.info("Step 1/3: Converting PDF to Markdown via Docling")
+        md_text = docling_md(input_path)
+        LOGGER.info("Docling conversion complete. Markdown length: %d chars", len(md_text))
 
-        # Materialize to list with progress bar for visibility
-        for r in tqdm(rows_iter, desc="Parsing", unit="row"):
+        LOGGER.info("Step 2/3: Parsing Markdown into rows")
+        for r in tqdm(parse_markdown_to_rows(md_text,
+                                             source_file=os.path.basename(input_path),
+                                             use_heuristics=args.heuristic_headings),
+                      desc="Parsing", unit="row"):
             rows.append(r)
 
-    LOGGER.info("Parsed %d rows (lines/sentences)", len(rows))
-
+    # Optional outline enrichment (works best with page_no)
     if args.use_pdf_outline:
         LOGGER.info("Enriching rows with PDF outline data")
         ranges = get_outline_ranges(input_path)
@@ -116,17 +91,27 @@ def main():
                         r["h1"] = oh1 or r.get("h1", "")
                         r["h2"] = oh2 or r.get("h2", "")
                         r["h3"] = oh3 or r.get("h3", "")
-                        r["section_path"] = " > ".join(
-                            [x for x in [r["h1"], r["h2"], r["h3"]] if x]
-                        )
+                        r["section_path"] = " > ".join([x for x in [r["h1"], r["h2"], r["h3"]] if x])
         else:
             LOGGER.info("No outline found; skipping enrichment")
 
-    LOGGER.info("Step 3/3: Writing to Excel: %s", out_path)
+    # Quality summary
+    LOGGER.info("Step 3/3: Quality summary before export")
+    total = len(rows)
+    n_empty = sum(1 for r in rows if not r.get("text"))
+    n_head = sum(1 for r in rows if r.get("section_type") == "heading")
+    n_table = sum(1 for r in rows if r.get("section_type") == "table")
+    n_bull  = sum(1 for r in rows if r.get("section_type") == "bullet")
+    LOGGER.info("Rows=%d | empty_text=%d | headings=%d | tables=%d | bullets=%d", total, n_empty, n_head, n_table, n_bull)
+    if n_empty > max(5, int(0.05 * total)):
+        LOGGER.warning("High empty-text ratio detected; consider using --backend docling")
+    if n_head < 10 and args.backend != "docling":
+        LOGGER.warning("Few headings detected; consider using --backend docling")
+
+    LOGGER.info("Writing to Excel: %s", out_path)
     to_xlsx(rows, out_path)
     elapsed = (datetime.now() - start_ts).total_seconds()
-    LOGGER.info("Done. Wrote %d rows to %s (%.2fs)", len(rows), out_path, elapsed)
-
+    LOGGER.info("Done. Wrote %d rows to %s (%.2fs)", total, out_path, elapsed)
 
 if __name__ == "__main__":
     main()

--- a/extractor/sentence_postprocess.py
+++ b/extractor/sentence_postprocess.py
@@ -1,27 +1,30 @@
 """
-Markdown -> structured rows with lightweight heuristics.
+Parse Markdown into structured rows.
 
-We preserve:
-- Headings with level (#, ##, ### ...)
-- Bulleted lines (-, *, •) as one row each
-- Table rows (markdown pipes) as one row each (is_table=1)
-- Paragraph lines -> naive sentence split (but not inside tables/bullets/headings)
-
-We also filter out typical TOC / references lines using simple keyword rules.
+Goals:
+- Default: rely on explicit Markdown headings (#, ##, ### ...) for reliability.
+- Optional: enable heuristics (numbered/caps) via flag for tricky docs.
+- Always forward-fill a simple `current_section` (last seen heading text).
 """
 
 import re
 from typing import Dict, Iterator, List, Optional
 
-
+# Explicit markdown headings
 _HEADING_RE = re.compile(r"^(?P<hashes>#{1,6})\s+(?P<text>.+)$")
+# Bullets and tables
 _BULLET_RE  = re.compile(r"^\s*([-*•]|\d+\.)\s+(.+)$")
-_TABLE_RE   = re.compile(r"^\s*\|.+\|\s*$")  # loose: line starts/ends with pipe
+_TABLE_RE   = re.compile(r"^\s*\|.+\|\s*$")
+# Basic cleaners
 _TOC_HINTS  = re.compile(r"(table of contents|contents|index)$", re.I)
 _REFERENCES = re.compile(r"^(references|bibliography|works cited)\b", re.I)
-
+# Sentence split (naive but reliable)
 _SENT_SPLIT = re.compile(r"(?<=[.!?])\s+(?=[A-Z0-9])")
 
+# --- Heuristic heading detectors (only used when use_heuristics=True) ---
+_NUM_HEADING = re.compile(r"^\s*(\d+(?:\.\d+){0,4})\s+[^\s].*$")
+_ALPHA_HEADING = re.compile(r"^\s*([A-Z])\.\s+[^\s].*$")
+_ROMAN_HEADING = re.compile(r"^\s*([IVXLCDM]+)\.\s+[^\s].*$", re.I)
 
 def _is_toc_or_reference(line: str) -> bool:
     l = line.strip()
@@ -29,136 +32,142 @@ def _is_toc_or_reference(line: str) -> bool:
         return False
     return bool(_TOC_HINTS.search(l)) or bool(_REFERENCES.search(l))
 
+def _caps_ratio(s: str) -> float:
+    letters = [c for c in s if c.isalpha()]
+    if not letters:
+        return 0.0
+    caps = [c for c in letters if c.isupper()]
+    return len(caps) / len(letters)
+
+def _infer_level_from_numbering(s: str) -> Optional[int]:
+    m = _NUM_HEADING.match(s)
+    if m:
+        return min(6, m.group(1).count(".") + 1)
+    if _ROMAN_HEADING.match(s):
+        return 1
+    if _ALPHA_HEADING.match(s):
+        return 2
+    return None
+
+def _maybe_heading_from_heuristics(s: str, last_level: int) -> Optional[int]:
+    text = s.strip()
+    if not text:
+        return None
+    words = text.split()
+    if len(words) <= 12 and not text.endswith(('.', '!', '?')) and _caps_ratio(text) >= 0.6:
+        return min(max(1, last_level + 1), 3)
+    return None
+# -----------------------------------------------------------------------
 
 def _emit_row(
     source_file: str,
     line_no: int,
     text: str,
     section_type: str,
-    heading_level: Optional[int],
+    heading_level: int,
     is_table: int,
-    h1: Optional[str],
-    h2: Optional[str],
-    h3: Optional[str],
+    current_section: str,
     page_no: int = 0,
+    h1: str = "", h2: str = "", h3: str = "", section_path: str = ""
 ) -> Dict:
-    path = " > ".join([x for x in [h1, h2, h3] if x])
     return {
         "source_file": source_file,
         "line_no": line_no,
         "page_no": page_no,
-        "section_type": section_type,  # one of: heading, bullet, table, text
+        "section_type": section_type,
         "heading_level": heading_level or 0,
         "is_table": is_table,
-        "h1": h1 or "",
-        "h2": h2 or "",
-        "h3": h3 or "",
-        "section_path": path,
+        "h1": h1,
+        "h2": h2,
+        "h3": h3,
+        "section_path": section_path,
+        "current_section": current_section,
         "text": text.strip(),
     }
 
-
-def parse_markdown_to_rows(md_text: str, source_file: str, page_no: int = 0) -> Iterator[Dict]:
+def parse_markdown_to_rows(
+    md_text: str,
+    source_file: str,
+    page_no: int = 0,
+    use_heuristics: bool = False,
+) -> Iterator[Dict]:
     """
-    Generate row dicts from markdown text.
-    Each row has: source_file, line_no, page_no, section_type, heading_level,
-    is_table, h1/h2/h3, section_path, text.
+    Default behaviour (use_heuristics=False):
+        - Only trust explicit markdown headings (#, ##, ...)
+        - Forward-fill `current_section` from last heading text
+    Optional behaviour (use_heuristics=True):
+        - Also detect numbered/roman/alpha headings and caps-heavy short lines
     """
-    current_h1: Optional[str] = ""
-    current_h2: Optional[str] = ""
-    current_h3: Optional[str] = ""
+    current_section = ""
+    last_heading_level = 0
 
     for i, raw in enumerate(md_text.splitlines(), start=1):
         line = raw.rstrip()
-        if not line:
-            continue
-        if _is_toc_or_reference(line):
-            # Skip obvious non-content sections; we could add more rules later
+        if not line or _is_toc_or_reference(line):
             continue
 
-        # Headings
+        # 1) Explicit markdown heading (most reliable)
         m = _HEADING_RE.match(line)
         if m:
             level = len(m.group("hashes"))
-            heading_text = m.group("text").strip()
-
-            if level == 1:
-                current_h1 = heading_text
-                current_h2 = ""
-                current_h3 = ""
-            elif level == 2:
-                if not current_h1:
-                    current_h1 = ""
-                current_h2 = heading_text
-                current_h3 = ""
-            else:
-                if not current_h1:
-                    current_h1 = ""
-                if not current_h2:
-                    current_h2 = ""
-                current_h3 = heading_text
-
+            text = m.group("text").strip()
+            current_section = text  # forward-fill simple context
+            last_heading_level = level
             yield _emit_row(
-                source_file=source_file,
-                line_no=i,
-                text=heading_text,
-                section_type="heading",
-                heading_level=level,
-                is_table=0,
-                h1=current_h1,
-                h2=current_h2,
-                h3=current_h3,
-                page_no=page_no,
+                source_file, i, text,
+                section_type="heading", heading_level=level, is_table=0,
+                current_section=current_section, page_no=page_no
             )
             continue
 
-        # Table rows
+        # 2) Table rows
         if _TABLE_RE.match(line):
             yield _emit_row(
-                source_file=source_file,
-                line_no=i,
-                text=line,
-                section_type="table",
-                heading_level=None,
-                is_table=1,
-                h1=current_h1,
-                h2=current_h2,
-                h3=current_h3,
-                page_no=page_no,
+                source_file, i, line,
+                section_type="table", heading_level=0, is_table=1,
+                current_section=current_section, page_no=page_no
             )
             continue
 
-        # Bullets
+        # 3) Bullets
         if _BULLET_RE.match(line):
-            # Keep bullet as a single row; downstream may sentence-split if desired
-            bullet_text = _BULLET_RE.sub(lambda m: m.group(0), line).strip()
             yield _emit_row(
-                source_file=source_file,
-                line_no=i,
-                text=bullet_text,
-                section_type="bullet",
-                heading_level=None,
-                is_table=0,
-                h1=current_h1,
-                h2=current_h2,
-                h3=current_h3,
-                page_no=page_no,
+                source_file, i, line.strip(),
+                section_type="bullet", heading_level=0, is_table=0,
+                current_section=current_section, page_no=page_no
             )
             continue
 
-        # Paragraph / plain text: naive sentence split
-        sentences: List[str] = _SENT_SPLIT.split(line.strip())
-        for s in sentences:
+        # 4) Optional heuristic headings (only if enabled)
+        if use_heuristics:
+            lvl = _infer_level_from_numbering(line)
+            if lvl is not None:
+                txt = line.split(None, 1)[1] if " " in line else line
+                current_section = txt
+                last_heading_level = lvl
+                yield _emit_row(
+                    source_file, i, txt,
+                    section_type="heading", heading_level=lvl, is_table=0,
+                    current_section=current_section, page_no=page_no
+                )
+                continue
+
+            lvl2 = _maybe_heading_from_heuristics(line, last_heading_level)
+            if lvl2 is not None:
+                current_section = line.strip()
+                last_heading_level = lvl2
+                yield _emit_row(
+                    source_file, i, current_section,
+                    section_type="heading", heading_level=lvl2, is_table=0,
+                    current_section=current_section, page_no=page_no
+                )
+                continue
+
+        # 5) Plain text -> naive sentence split
+        for s in _SENT_SPLIT.split(line.strip()):
             if s:
                 yield _emit_row(
-                    source_file=source_file,
-                    line_no=i,
-                    text=s,
-                    section_type="text",
-                    heading_level=None,
-                    is_table=0,
-                    h1=current_h1,
-                    h2=current_h2,
-                    h3=current_h3,
-                    page_no=page_no,
+                    source_file, i, s,
+                    section_type="text", heading_level=0, is_table=0,
+                    current_section=current_section, page_no=page_no
                 )


### PR DESCRIPTION
## Summary
- restore a stable markdown parser that records `current_section` and exposes optional heading heuristics
- make the Docling backend the CLI default, add the `--heuristic-headings` flag, and log extraction quality metrics
- ensure the Excel export includes the new `current_section` column

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e3dc7dfaac8332b2524369bb5b5f86