### PR TITLE
Add metadata-aware export options and Streamlit metadata inputs

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,11 +1,11 @@
-import os
-import io
 import pandas as pd
 import streamlit as st
 
 from extractor.backends.docling_backend import docling_md
 from extractor.sentence_postprocess import parse_markdown_to_rows
+from extractor.export import to_xlsx_with_options
 
+# Optional backends wired in earlier tasks
 def _pymu_md_pages(path):
     from extractor.backends.pymupdf4llm_backend import extract_markdown_pages
     return list(extract_markdown_pages(path))
@@ -14,31 +14,44 @@ def _ade_rows(path):
     from extractor.backends.agenticdoc_backend import extract_rows
     return extract_rows(path)
 
-st.set_page_config(page_title="Green Guard – Extractor", layout="wide")
+st.set_page_config(page_title="Green Guard – ESG Extractor", layout="wide")
 st.title("Green Guard — ESG PDF Extractor (MVP)")
-backend = st.selectbox("Backend", ["docling", "pymupdf4llm", "agenticdoc"])
-st.caption("Set VISION_AGENT_API_KEY in your environment for Agentic-Doc.")
 
-uploaded = st.file_uploader("Upload a PDF", type=["pdf"])
-run = st.button("Extract")
+with st.sidebar:
+    st.markdown("### Extraction Settings")
+    backend = st.selectbox("Backend", ["docling", "pymupdf4llm", "agenticdoc"])
+    st.caption("Agentic-Doc requires VISION_AGENT_API_KEY.")
 
-def download_buttons(df: pd.DataFrame):
-    csv = df.to_csv(index=False).encode("utf-8")
-    st.download_button("Download CSV", data=csv, file_name="extracted.csv", mime="text/csv")
-    bio = io.BytesIO()
-    with pd.ExcelWriter(bio, engine="openpyxl") as w:
-        df.to_excel(w, index=False, sheet_name="extracted")
-    st.download_button("Download Excel", data=bio.getvalue(), file_name="extracted.xlsx",
-                       mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+st.markdown("### Upload & Metadata")
+with st.form("upload_form", clear_on_submit=False):
+    uploaded = st.file_uploader("Upload ESG / Sustainability PDF", type=["pdf"])
+    company = st.text_input("Company", value="")
+    year = st.text_input("Year", value="")
+    reporting_options = [
+        "GRI (Global Reporting Initiative)",
+        "ISSB (International Sustainability Standards Board)",
+        "IFRS S1 & S2",
+        "ESRS (European Sustainability Reporting Standards)",
+        "TCFD (Taskforce on Climate-related Financial Disclosures)",
+        "CDP (Carbon Disclosure Project)",
+        "SASB (Sustainability Accounting Standards Board)",
+        "ISO 14001 (Environmental Management Systems)",
+        "ISO 26000 (Social Responsibility)",
+        "Other",
+    ]
+    reporting_std = st.selectbox("Reporting Standard", reporting_options, index=0)
+    submitted = st.form_submit_button("Extract")
 
-if run:
+if submitted:
     if not uploaded:
-        st.warning("Please upload a PDF first.")
+        st.warning("Please upload a PDF.")
         st.stop()
 
     tmp_path = f"/tmp/{uploaded.name}"
     with open(tmp_path, "wb") as f:
         f.write(uploaded.read())
+
+    metadata = {"Company": company, "Year": year, "Reporting Standard": reporting_std}
 
     with st.status("Extracting...", state="running") as status:
         try:
@@ -58,11 +71,56 @@ if run:
 
             df = pd.DataFrame(rows)
             status.update(label=f"Done. {len(df)} rows.", state="complete")
+
         except Exception as e:
             st.error(f"Extraction failed: {e}")
             st.stop()
 
-    st.subheader("Preview")
+    # Build an Excel with renamed headers + hidden columns and metadata
+    excel_bytes = to_xlsx_with_options(
+        rows,
+        out_path=None,  # in-memory for download
+        metadata=metadata,
+        rename_map=None,  # use defaults
+        hidden_cols=["Page_No", "H1", "H2", "H3"],  # your preference
+    )
+
+    # Apply the same renaming to the on-screen preview for consistency
+    rename_map = {
+        "source_file": "Source",
+        "line_no": "Line_No",
+        "page_no": "Page_No",
+        "section_type": "Section Type",
+        "heading_level": "Heading Level",
+        "is_table": "Is Table",
+        "h1": "H1",
+        "h2": "H2",
+        "h3": "H3",
+        "section_path": "Section",
+        "text": "Text",
+        "current_section": "Current Section",
+    }
+    if not df.empty:
+        df = df.rename(columns=rename_map)
+        df.insert(0, "Company", company)
+        df.insert(1, "Year", year)
+        df.insert(2, "Reporting Standard", reporting_std)
+
+    st.markdown("### Preview")
     st.dataframe(df.head(300), use_container_width=True)
-    st.subheader("Download")
-    download_buttons(df)
+
+    st.markdown("### Download")
+    # CSV
+    st.download_button(
+        "Download CSV",
+        data=df.to_csv(index=False).encode("utf-8"),
+        file_name="extracted.csv",
+        mime="text/csv",
+    )
+    # Excel (hidden cols applied)
+    st.download_button(
+        "Download Excel (with hidden columns)",
+        data=excel_bytes.getvalue(),
+        file_name="extracted.xlsx",
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )

--- a/extractor/export.py
+++ b/extractor/export.py
@@ -1,23 +1,106 @@
 import pandas as pd
-from typing import Dict, List
+from typing import Dict, List, Optional
+from io import BytesIO
 
 _REQUIRED_COLS = [
-    "source_file","line_no","page_no",
-    "section_type","heading_level","is_table",
-    "h1","h2","h3","section_path",
-    "current_section",   # NEW
-    "text",
+    "source_file", "line_no", "page_no",
+    "section_type", "heading_level", "is_table",
+    "h1", "h2", "h3", "section_path",
+    "current_section", "text",
 ]
 
-def to_xlsx(rows: List[Dict], out_path: str) -> None:
-    if not rows:
-        df = pd.DataFrame(columns=_REQUIRED_COLS)
-        df.to_excel(out_path, index=False)
-        return
+# Default renames you asked for
+DEFAULT_RENAME = {
+    "source_file": "Source",
+    "line_no": "Line_No",
+    "page_no": "Page_No",
+    "section_type": "Section Type",
+    "heading_level": "Heading Level",
+    "is_table": "Is Table",
+    "h1": "H1",
+    "h2": "H2",
+    "h3": "H3",
+    "section_path": "Section",
+    "text": "Text",
+    "current_section": "Current Section",
+}
 
+DEFAULT_HIDDEN = {"Page_No", "H1", "H2", "H3"}
+
+
+def _ensure_cols(df: pd.DataFrame) -> pd.DataFrame:
+    for col in _REQUIRED_COLS:
+        if col not in df.columns:
+            df[col] = None
+    return df
+
+
+def _order_cols(df: pd.DataFrame, meta_cols: List[str], rename_map: Dict[str, str]) -> pd.DataFrame:
+    base_keys = [
+        "source_file", "line_no", "page_no", "section_type", "heading_level", "is_table",
+        "section_path", "current_section", "text", "h1", "h2", "h3",
+    ]
+    renamed_base = [rename_map.get(key, key) for key in base_keys]
+    ordered = meta_cols + [col for col in renamed_base if col in df.columns]
+    extras = [col for col in df.columns if col not in ordered]
+    return df[ordered + extras]
+
+
+def to_xlsx(rows: List[Dict], out_path: str) -> None:
+    """Backwards-compatible: no meta, default names."""
+    if not rows:
+        pd.DataFrame(columns=_REQUIRED_COLS).rename(columns=DEFAULT_RENAME).to_excel(out_path, index=False)
+        return
     df = pd.DataFrame(rows)
-    for c in _REQUIRED_COLS:
-        if c not in df.columns:
-            df[c] = None
-    df = df[_REQUIRED_COLS]
+    df = _ensure_cols(df).rename(columns=DEFAULT_RENAME)
+    df = _order_cols(df, meta_cols=[], rename_map=DEFAULT_RENAME)
     df.to_excel(out_path, index=False)
+
+
+def to_xlsx_with_options(
+    rows: List[Dict],
+    out_path: Optional[str] = None,
+    metadata: Optional[Dict[str, str]] = None,  # {"Company": "...", "Year": "2024", "Reporting Standard": "..."}
+    rename_map: Optional[Dict[str, str]] = None,
+    hidden_cols: Optional[List[str]] = None,
+) -> BytesIO:
+    """
+    Write Excel with metadata columns, renamed headers, and hidden columns.
+    If out_path is None, returns an in-memory BytesIO (useful for Streamlit download).
+    """
+    if rows:
+        df = pd.DataFrame(rows)
+    else:
+        df = pd.DataFrame(columns=_REQUIRED_COLS)
+
+    df = _ensure_cols(df)
+
+    rename_map = rename_map or DEFAULT_RENAME
+    df = df.rename(columns=rename_map)
+
+    meta = metadata or {}
+    for key in ["Company", "Year", "Reporting Standard"]:
+        df[key] = meta.get(key, "")
+    df = _order_cols(df, meta_cols=["Company", "Year", "Reporting Standard"], rename_map=rename_map)
+
+    bio = BytesIO()
+    with pd.ExcelWriter(out_path or bio, engine="openpyxl") as writer:
+        df.to_excel(writer, index=False, sheet_name="extracted")
+        worksheet = writer.sheets["extracted"]
+        to_hide = set(hidden_cols or DEFAULT_HIDDEN)
+        header_row = 1
+        header_names = {
+            worksheet.cell(row=header_row, column=col).value: col
+            for col in range(1, worksheet.max_column + 1)
+        }
+        for name in to_hide:
+            col_idx = header_names.get(name)
+            if col_idx:
+                column_letter = worksheet.cell(row=1, column=col_idx).column_letter
+                worksheet.column_dimensions[column_letter].hidden = True
+
+    if out_path:
+        bio.seek(0)
+        return bio
+    bio.seek(0)
+    return bio


### PR DESCRIPTION
## Summary
- add an enhanced Excel exporter that supports metadata columns, customizable headers, and hidden columns
- update the Streamlit app with metadata inputs, reporting standard options, and download buttons that use the new exporter

## Testing
- python -m compileall extractor/export.py app/streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_b_68e42569323883328084bf6506189186