### PR TITLE
Add Streamlit configuration for upload limits and theme

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,17 @@
+[server]
+maxUploadSize = 200
+enableXsrfProtection = true
+enableCORS = false
+
+[browser]
+gatherUsageStats = false
+
+[client]
+toolbarMode = "minimal"
+
+[theme]
+base = "dark"
+primaryColor = "#5DC28B"
+backgroundColor = "#0E1117"
+secondaryBackgroundColor = "#1B1F2A"
+textColor = "#E1E5EA"


### PR DESCRIPTION
## Summary
- add a Streamlit configuration file to control upload size, security, and theme options

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e44cfffd3c83329937442e3f6030b5