### PR TITLE
Ensure Streamlit app can import extractor package

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -3,6 +3,15 @@ import io
 import pandas as pd
 import streamlit as st
 
+# --- make sure local package "extractor" is importable on Streamlit Cloud ---
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]   # repo root
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+# ----------------------------------------------------------------------------
+
 from extractor.backends.docling_backend import docling_md
 from extractor.sentence_postprocess import parse_markdown_to_rows
 from extractor.export import to_xlsx_with_options

--- a/extractor/requirements.txt
+++ b/extractor/requirements.txt
@@ -1,5 +1,6 @@
 ADE
 docling
+pymupdf
 pandas
 openpyxl
 tqdm


### PR DESCRIPTION
## Summary
- add repository root to `sys.path` in the Streamlit app so local extractor modules import correctly
- ensure extractor requirements include the PyMuPDF dependency for cloud installs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e44f70f6288332992052c576313eb5