### PR TITLE
Update README with document parser overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,45 @@
-# Green Guard — Extraction MVP (Step 1)
+# Green Guard — Document Parser
 
-This step builds a robust **PDF → Markdown → Sentences → .xlsx** pipeline using **Docling** with detailed logs.
+Green Guard is a focused document-to-structured-data pipeline designed to extract sentences, metadata, and tabular markers from PDF reports. The project powers downstream sustainability and compliance workflows by delivering clean, analyzable spreadsheets from messy source documents.
 
-## Quick start
+## 🚀 What makes it useful
+- **Reliable PDF ingestion.** Uses [Docling](https://github.com/DS4SD/docling) to convert PDFs into Markdown with stable layout fidelity.
+- **Sentence-first parsing.** Breaks Markdown into sentence-level rows while preserving headings, bullet structure, and table context flags.
+- **Spreadsheet-ready output.** Exports processed text into `.xlsx` files with metadata columns tailored for labeling and review.
+- **Transparent processing.** Verbose logging highlights every transformation step to make debugging and auditing easy.
+
+## 🧭 How the pipeline works
+1. **PDF ➜ Markdown.** Docling renders each page, preserving heading hierarchy and list markers.
+2. **Markdown ➜ Structured rows.** Custom parsing cleans artifacts, segments text, and tags row context (heading level, bullet state, table membership).
+3. **Rows ➜ Excel workbook.** The exporter writes cleaned rows and metadata into separate worksheet columns for quick filtering.
+
+## 📂 Project layout
+```
+extractor/
+  backends/             # Interfaces to additional parsing engines (Docling today, more soon)
+  cli.py                # Entry point for running the pipeline from the command line
+  export.py             # Excel writer utilities
+  sentence_postprocess.py  # Sentence segmentation and cleanup routines
+  text_clean.py         # Markdown-specific normalization helpers
+  utils/                # Shared helpers (logging, I/O, constants)
+app/                    # Placeholder for future UI / Streamlit prototype
+```
+
+## 🏁 Quick start
 ```bash
 pip install -r extractor/requirements.txt
 python extractor/cli.py --in path/to/your.pdf --out outputs/your.xlsx --log-level INFO
 ```
 
-## What it does
+This command converts your PDF into an Excel workbook with columns such as `text`, `heading_level`, `is_bullet`, and `is_table` for downstream analysis.
 
-1. Converts PDF to Markdown via Docling
-2. Parses Markdown into sentences/lines while preserving:
-   - Headings (with level)
-   - Bulleted lines
-   - Table rows (kept as single lines; marked is_table=1)
-3. Exports to .xlsx with metadata columns
+## 🛣️ Roadmap
+- Optional backend support (Agentic-Doc, PyMuPDF4LLM) for specialized PDFs.
+- Streamlit-based reviewer dashboard for rapid validation.
+- Smart chunking and annotation-ready exports for ML labeling workflows.
 
-## Next steps
+## 🤝 Contributing
+Issues and pull requests are welcome! If you spot a parsing edge case or have a feature request, open an issue describing the document type and desired output. For significant contributions, please coordinate on GitHub Discussions first to align on approach.
 
-Only once this initial set up is done and stable I would next like to add optional backends (Agentic-Doc / PyMuPDF4LLM) and a Streamlit MVP.
+---
+Green Guard is maintained by the Green Guard team to accelerate compliant, traceable document understanding.


### PR DESCRIPTION
## Summary
- replace the minimal README with a fuller overview of the document parsing pipeline
- document the quick start command, repository layout, and upcoming roadmap

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e64e721bac833285587b876684e852